### PR TITLE
Facilitate additional links for resources (and theme updates)

### DIFF
--- a/data/services.cs.yaml
+++ b/data/services.cs.yaml
@@ -1,7 +1,9 @@
 ---
 - id: memomap
   title: MemoMap
-  url: https://www.memomap.cz/
+  links:
+    - title: Přejít na MemoMap
+      url: https://www.memomap.cz/
   icon: meeting_room
   image: memomap.png
   content: |

--- a/data/services.cs.yaml
+++ b/data/services.cs.yaml
@@ -2,8 +2,10 @@
 - id: memomap
   title: MemoMap
   links:
-    - title: Přejít na MemoMap
+    - title: Vstup do MemoMap
       url: https://www.memomap.cz/
+    - title: Více o MemoMap
+      url: https://ehri.cz/services/memomappraha/
   icon: meeting_room
   image: memomap.png
   content: |

--- a/data/services.en.yaml
+++ b/data/services.en.yaml
@@ -1,7 +1,9 @@
 ---
 - id: memomap
   title: MemoMap
-  url: https://www.memomap.cz/
+  links:
+    - title: Go to MemoMap
+      url: https://www.memomap.cz/
   icon: meeting_room
   image: memomap.png
   content: |

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,9 +9,9 @@
         <div id="welcome-image3"></div>
         <div id="welcome-text">
             {{ .Content }}
+            <a class="button-primary" href="{{ relLangURL "about" }}">{{ i18n "learn_more" }}</a>
         </div>
 
-        <a class="button-primary" href="{{ relLangURL "about" }}">{{ i18n "learn_more" }}</a>
     </div>
 </section>
 

--- a/layouts/services/single.html
+++ b/layouts/services/single.html
@@ -1,0 +1,11 @@
+{{/* This partial is overridden to remove the 'services' class from the
+section element, which causes a list style to apply to the services boxes. */}}
+{{ define "main" }}
+    <section class="page-content">
+
+        <h1>{{ .Title }}</h1>
+        {{ .Content }}
+
+        {{ partial "services" . }}
+    </section>
+{{ end }}


### PR DESCRIPTION
This PR updates the ehri-nn theme to latest upstream and applies some fixes to preserve the current look of the CZ site:

 - override services layout template, since newer one applies a list rather than grid view
 - modify index page to prevent bad layout on welcome link

Additional URLs can be added to services by adding new items to the `links` key as title/url key-pairs. The existing `url` key is still supported.