### PR TITLE
Switch the default (FontAwesome) Twitter icon for an X

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,0 +1,14 @@
+<div class="social">
+    <div class="follow-buttons">
+        <a class="follow-button" href="{{ site.Params.facebookUrl }}" title="Follow EHRI on Facebook">
+            <i class="fa fa-2x fa-facebook" aria-hidden="true"></i>
+            <span class="sr-only">Facebook</span>
+        </a>
+
+        <a class="follow-button" href="{{ site.Params.twitterUrl }}" title="Follow EHRI on X">
+            <i class="fa fa-fw fa-2x" aria-hidden="true" style="font-weight: bolder">&#120143;</i>
+            <span class="sr-only">X (formerly Twitter)</span>
+        </a>
+    </div>
+</div>
+


### PR DESCRIPTION
Override the `social.html` partial template and switch the FontAwesome 4.7 Twitter icon for an X icon.

This can be tweaked with CSS if necessary, e.g. by adding `style="font-weight: bolder"` to the `<i>` element.